### PR TITLE
Add template title as note suggestion when creating a record

### DIFF
--- a/app/operations/records/build_from_params.rb
+++ b/app/operations/records/build_from_params.rb
@@ -41,7 +41,7 @@ module Records
         account_id: template.account_id,
         category_id: template.category_id,
         amount_cents: template.amount_cents,
-        note: template.note
+        note: template.note.presence || template.title
       )
     end
   end

--- a/test/operations/records/build_from_params_test.rb
+++ b/test/operations/records/build_from_params_test.rb
@@ -55,6 +55,17 @@ module Records
       assert_equal Time.zone.today, result.record.occurred_on
     end
 
+    test "building from template with empty note" do
+      account = create(:account)
+      template = create(:template, title: "My title", note: "")
+
+      result = Records::BuildFromParams.call(
+        account: account, params: {template: template.id.to_s}
+      )
+
+      assert_equal template.title, result.record.note
+    end
+
     test "building from missing template" do
       account = create(:account)
       assert_raises ActiveRecord::RecordNotFound do


### PR DESCRIPTION
Added the template title as a note suggestion when creating a record from template. The goal is to make it easier to fill in the note field by providing an automatic suggestion based on the selected template’s name. This aims to improve the user experience by speeding up form filling with relevant contextual information, reducing manual effort.